### PR TITLE
Add reactor-kotlin-extensions for toMono() and toFlux()

### DIFF
--- a/reactor/build.gradle
+++ b/reactor/build.gradle
@@ -5,4 +5,5 @@ dependencies {
 
     compileOnly "io.micronaut:micronaut-tracing"
     api "io.projectreactor:reactor-core:$reactorVersion"
+    api "io.projectreactor.kotlin:reactor-kotlin-extensions:1.0.2.RELEASE"
 }


### PR DESCRIPTION
These helpers are using extensively when building an app with reactor, but they moved from reactor-core to the kotlin-extensions-module and litters the compilation with warnings:

> w: /UseCase.kt: (53, 32): 'toFlux(): Flux<T>' is deprecated. To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions
> w: /UseCase.kt: (74, 44): 'toMono(): Mono<T>' is deprecated. To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions