### PR TITLE
build: bump up micronaut from 2.4.4 to 2.5.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=1.1.2-SNAPSHOT
+projectVersion=1.2.0-SNAPSHOT
 micronautDocsVersion=2.0.0.RC1
 micronautVersion=2.5.7
 micronautTestVersion=2.3.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ developers=Graeme Rocher
 
 
 githubBranch=master
-githubCoreBranch=2.2.x
+githubCoreBranch=3.0.x
 bomProperty=micronautReactorVersion
 bomProperties=reactorVersion
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 projectVersion=1.1.2-SNAPSHOT
 micronautDocsVersion=2.0.0.RC1
-micronautVersion=2.4.4
+micronautVersion=2.5.7
 micronautTestVersion=2.3.3
 
 groovyVersion=3.0.8

--- a/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/ServerSentEventSpec.groovy
+++ b/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/ServerSentEventSpec.groovy
@@ -4,11 +4,13 @@ import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Produces
 import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.sse.Event
 import io.reactivex.Flowable
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
@@ -66,12 +68,13 @@ class ServerSentEventSpec extends Specification {
     }
 
     void "test receive error from supplier"() {
-
         when:
         List<Event<String>> events = client.exception().collectList().block()
 
         then:
-        events.size() == 0
+        HttpClientResponseException ex = thrown()
+        ex.status == HttpStatus.INTERNAL_SERVER_ERROR
+        ex.message == "Internal Server Error"
     }
 
     @Client('/sse')


### PR DESCRIPTION
- build: bump up micronaut from 2.4.4 to 2.5.7
- Change test to mimic core behaviour see: https://github.com/micronaut-projects/micronaut-core/commit/0f6cec56d635326911077fb221df40f0c4d9fbe6
- set project version to 1.2.0-SNAPSHOT
- change github core branch to 3.0.x