### PR TITLE
Change all responses in ReactorHttpClient from Flux to Mono

### DIFF
--- a/reactor-http-client/src/main/java/io/micronaut/reactor/http/client/BridgedReactorHttpClient.java
+++ b/reactor-http-client/src/main/java/io/micronaut/reactor/http/client/BridgedReactorHttpClient.java
@@ -23,7 +23,7 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.HttpClient;
-import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * Internal bridge for the HTTP client.
@@ -50,58 +50,58 @@ class BridgedReactorHttpClient implements ReactorHttpClient {
     }
 
     @Override
-    public <I, O, E> Flux<HttpResponse<O>> exchange(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType, @NonNull Argument<E> errorType) {
-        return Flux.from(httpClient.exchange(request, bodyType, errorType));
+    public <I, O, E> Mono<HttpResponse<O>> exchange(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType, @NonNull Argument<E> errorType) {
+        return Mono.from(httpClient.exchange(request, bodyType, errorType));
     }
 
     @Override
-    public <I, O> Flux<HttpResponse<O>> exchange(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType) {
-        return Flux.from(httpClient.exchange(request, bodyType));
+    public <I, O> Mono<HttpResponse<O>> exchange(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType) {
+        return Mono.from(httpClient.exchange(request, bodyType));
     }
 
     @Override
-    public <I, O, E> Flux<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType, @NonNull Argument<E> errorType) {
-        return Flux.from(httpClient.retrieve(request, bodyType));
+    public <I, O, E> Mono<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType, @NonNull Argument<E> errorType) {
+        return Mono.from(httpClient.retrieve(request, bodyType));
     }
 
     @Override
-    public <I> Flux<HttpResponse<ByteBuffer>> exchange(@NonNull HttpRequest<I> request) {
-        return Flux.from(httpClient.exchange(request));
+    public <I> Mono<HttpResponse<ByteBuffer>> exchange(@NonNull HttpRequest<I> request) {
+        return Mono.from(httpClient.exchange(request));
     }
 
     @Override
-    public Flux<HttpResponse<ByteBuffer>> exchange(@NonNull String uri) {
-        return Flux.from(httpClient.exchange(uri));
+    public Mono<HttpResponse<ByteBuffer>> exchange(@NonNull String uri) {
+        return Mono.from(httpClient.exchange(uri));
     }
 
     @Override
-    public <O> Flux<HttpResponse<O>> exchange(@NonNull String uri, @NonNull Class<O> bodyType) {
-        return Flux.from(httpClient.exchange(uri, bodyType));
+    public <O> Mono<HttpResponse<O>> exchange(@NonNull String uri, @NonNull Class<O> bodyType) {
+        return Mono.from(httpClient.exchange(uri, bodyType));
     }
 
     @Override
-    public <I, O> Flux<HttpResponse<O>> exchange(@NonNull HttpRequest<I> request, @NonNull Class<O> bodyType) {
-        return Flux.from(httpClient.exchange(request, bodyType));
+    public <I, O> Mono<HttpResponse<O>> exchange(@NonNull HttpRequest<I> request, @NonNull Class<O> bodyType) {
+        return Mono.from(httpClient.exchange(request, bodyType));
     }
 
     @Override
-    public <I, O> Flux<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType) {
-        return Flux.from(httpClient.retrieve(request, bodyType));
+    public <I, O> Mono<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType) {
+        return Mono.from(httpClient.retrieve(request, bodyType));
     }
 
     @Override
-    public <I, O> Flux<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Class<O> bodyType) {
-        return Flux.from(httpClient.retrieve(request, bodyType));
+    public <I, O> Mono<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Class<O> bodyType) {
+        return Mono.from(httpClient.retrieve(request, bodyType));
     }
 
     @Override
-    public <I> Flux<String> retrieve(@NonNull HttpRequest<I> request) {
-        return Flux.from(httpClient.retrieve(request));
+    public <I> Mono<String> retrieve(@NonNull HttpRequest<I> request) {
+        return Mono.from(httpClient.retrieve(request));
     }
 
     @Override
-    public Flux<String> retrieve(@NonNull String uri) {
-        return Flux.from(httpClient.retrieve(uri));
+    public Mono<String> retrieve(@NonNull String uri) {
+        return Mono.from(httpClient.retrieve(uri));
     }
 
     @Override

--- a/reactor-http-client/src/main/java/io/micronaut/reactor/http/client/ReactorHttpClient.java
+++ b/reactor-http-client/src/main/java/io/micronaut/reactor/http/client/ReactorHttpClient.java
@@ -23,7 +23,7 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.HttpClientConfiguration;
-import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.net.URL;
 
@@ -36,45 +36,45 @@ import java.net.URL;
 public interface ReactorHttpClient extends HttpClient {
 
     @Override
-    default <I, O> Flux<HttpResponse<O>> exchange(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType) {
-        return Flux.from(HttpClient.super.exchange(request, bodyType));
+    default <I, O> Mono<HttpResponse<O>> exchange(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType) {
+        return Mono.from(HttpClient.super.exchange(request, bodyType));
     }
 
     @Override
-    <I, O, E> Flux<HttpResponse<O>> exchange(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType, @NonNull Argument<E> errorType);
+    <I, O, E> Mono<HttpResponse<O>> exchange(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType, @NonNull Argument<E> errorType);
 
     @Override
-    default <I, O, E> Flux<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType, @NonNull Argument<E> errorType) {
-        return Flux.from(HttpClient.super.retrieve(request, bodyType, errorType));
+    default <I, O, E> Mono<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType, @NonNull Argument<E> errorType) {
+        return Mono.from(HttpClient.super.retrieve(request, bodyType, errorType));
     }
 
     @Override
-    default <I> Flux<HttpResponse<ByteBuffer>> exchange(@NonNull HttpRequest<I> request) {
-        return Flux.from(HttpClient.super.exchange(request));
+    default <I> Mono<HttpResponse<ByteBuffer>> exchange(@NonNull HttpRequest<I> request) {
+        return Mono.from(HttpClient.super.exchange(request));
     }
 
     @Override
-    default Flux<HttpResponse<ByteBuffer>> exchange(@NonNull String uri) {
-        return Flux.from(HttpClient.super.exchange(uri));
+    default Mono<HttpResponse<ByteBuffer>> exchange(@NonNull String uri) {
+        return Mono.from(HttpClient.super.exchange(uri));
     }
 
     @Override
-    default <O> Flux<HttpResponse<O>> exchange(@NonNull String uri, @NonNull Class<O> bodyType) {
-        return Flux.from(HttpClient.super.exchange(uri, bodyType));
+    default <O> Mono<HttpResponse<O>> exchange(@NonNull String uri, @NonNull Class<O> bodyType) {
+        return Mono.from(HttpClient.super.exchange(uri, bodyType));
     }
 
     @Override
-    default <I, O> Flux<HttpResponse<O>> exchange(@NonNull HttpRequest<I> request, @NonNull Class<O> bodyType) {
-        return Flux.from(HttpClient.super.exchange(request, bodyType));
+    default <I, O> Mono<HttpResponse<O>> exchange(@NonNull HttpRequest<I> request, @NonNull Class<O> bodyType) {
+        return Mono.from(HttpClient.super.exchange(request, bodyType));
     }
 
     @Override
-    default <I, O> Flux<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType) {
-        return Flux.from(HttpClient.super.retrieve(request, bodyType));
+    default <I, O> Mono<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType) {
+        return Mono.from(HttpClient.super.retrieve(request, bodyType));
     }
 
     @Override
-    default <I, O> Flux<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Class<O> bodyType) {
+    default <I, O> Mono<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Class<O> bodyType) {
         return retrieve(
                 request,
                 Argument.of(bodyType),
@@ -83,7 +83,7 @@ public interface ReactorHttpClient extends HttpClient {
     }
 
     @Override
-    default <I> Flux<String> retrieve(@NonNull HttpRequest<I> request) {
+    default <I> Mono<String> retrieve(@NonNull HttpRequest<I> request) {
         return retrieve(
                 request,
                 Argument.STRING,
@@ -92,7 +92,7 @@ public interface ReactorHttpClient extends HttpClient {
     }
 
     @Override
-    default Flux<String> retrieve(@NonNull String uri) {
+    default Mono<String> retrieve(@NonNull String uri) {
         return retrieve(
                 HttpRequest.GET(uri),
                 Argument.STRING,

--- a/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/HttpGetSpec.groovy
+++ b/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/HttpGetSpec.groovy
@@ -22,7 +22,7 @@ class HttpGetSpec extends Specification{
 
     void "test mono empty list returns ok"() {
         when:
-        HttpResponse response = client.exchange(HttpRequest.GET("/get/emptyList/mono"), Argument.listOf(Book)).blockFirst()
+        HttpResponse response = client.exchange(HttpRequest.GET("/get/emptyList/mono"), Argument.listOf(Book)).block()
 
         then:
         noExceptionThrown()

--- a/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/JsonBodyBindingSpec.groovy
+++ b/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/JsonBodyBindingSpec.groovy
@@ -24,7 +24,7 @@ class JsonBodyBindingSpec extends Specification {
         def json = '{"message":"foo"}'
         def response = reactorHttpClient.exchange(
                 HttpRequest.POST('/json/mono', json), String
-        ).blockFirst()
+        ).block()
 
         then:
         response.body() == "$json".toString()

--- a/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/ReactorCrudSpec.groovy
+++ b/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/ReactorCrudSpec.groovy
@@ -64,7 +64,7 @@ class ReactorCrudSpec extends Specification {
         book != null
         book.title == "The Stand"
         book.id == 1
-        reactorHttpClient.retrieve(HttpRequest.GET("/reactor/books/" + book.id), Book).blockFirst()
+        reactorHttpClient.retrieve(HttpRequest.GET("/reactor/books/" + book.id), Book).block()
                 .title == "The Stand"
 
         when:


### PR DESCRIPTION
This PR change all responses in ReactorHttpClient from Flux to Mono as they only return one result and adjust all tests accordingly.
Semantically Mono is better fit for a Publisher returning zero or one item, Flux is (as used in the ReactorStreamingHttpClient) the better fit for 0-N items. Using Flux for one response makes the API unclear, I was really confused if the ReactorHttpClient could return multiple responses for one request. 