### PR TITLE
Allow closing ReactorHttpClients

### DIFF
--- a/reactor-http-client/src/main/java/io/micronaut/reactor/http/client/BridgedReactorHttpClient.java
+++ b/reactor-http-client/src/main/java/io/micronaut/reactor/http/client/BridgedReactorHttpClient.java
@@ -109,5 +109,23 @@ class BridgedReactorHttpClient implements ReactorHttpClient {
         return httpClient.isRunning();
     }
 
+    @Override
+    public void close() {
+        httpClient.close();
+    }
+
+    @Override
+    @NonNull
+    public HttpClient start() {
+        httpClient.start();
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public HttpClient stop() {
+        httpClient.stop();
+        return this;
+    }
 }
 

--- a/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/RxClientCloseSpec.groovy
+++ b/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/RxClientCloseSpec.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.reactor.http.client
+
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+class RxClientCloseSpec extends Specification {
+    def "confirm ReactorHttpClient can be stopped"() {
+        given:
+        def client = ReactorHttpClient.create(new URL("http://localhost"))
+
+        expect:
+        client.isRunning()
+
+        when:
+        client.stop()
+        then:
+        new PollingConditions().eventually {
+            !client.isRunning()
+        }
+    }
+
+    def "confirm ReactorHttpClient can be closed"() {
+        given:
+        def client = ReactorHttpClient.create(new URL("http://localhost"))
+
+        expect:
+        client.isRunning()
+
+        when:
+        client.close()
+        then:
+        new PollingConditions().eventually {
+            !client.isRunning()
+        }
+    }
+}


### PR DESCRIPTION
The delegation for close, start and stop were missing.
Same patch as https://github.com/micronaut-projects/micronaut-rxjava2/pull/51