### PR TITLE
Use reactor-bom instead of managed dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,6 @@
 projectVersion=3.0.0-SNAPSHOT
 projectGroup=io.micronaut.reactor
 
-micronautDocsVersion=2.0.0
-micronautVersion=4.0.0-SNAPSHOT
-micronautTestVersion=3.5.0
-groovyVersion=4.0.5
-spockVersion=2.3-groovy-4.0
-
 title=Micronaut Reactor
 projectDesc=Integration between Micronaut and Reactor
 projectUrl=https://micronaut.io

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,20 @@
 [versions]
-managed-reactor = "3.4.23"
+micronaut = "4.0.0-SNAPSHOT"
+micronaut-docs = "2.0.0"
+micronaut-test = "3.7.0"
+groovy = "4.0.5"
+spock = "2.3-groovy-4.0"
 
 rxjava2 = "2.2.21"
 rxjava3 = "3.1.5"
 
-[libraries]
-managed-reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "managed-reactor" }
-managed-reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "managed-reactor" }
+managed-reactor-bom = "2020.0.24"
 
+[libraries]
+boms-reactor = { module = "io.projectreactor:reactor-bom", version.ref = "managed-reactor-bom" }
+
+reactor-core = { module = "io.projectreactor:reactor-core" }
+reactor-test = { module = "io.projectreactor:reactor-test" }
 brave-instrumentation-http = { module = "io.zipkin.brave:brave-instrumentation-http" }
 brave-opentracing = { module = "io.opentracing.brave:brave-opentracing" }
 zipkin-reporter = { module = "io.zipkin.reporter2:zipkin-reporter" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,9 +14,5 @@ managed-reactor-bom = "2020.0.24"
 boms-reactor = { module = "io.projectreactor:reactor-bom", version.ref = "managed-reactor-bom" }
 
 reactor-core = { module = "io.projectreactor:reactor-core" }
-reactor-test = { module = "io.projectreactor:reactor-test" }
-brave-instrumentation-http = { module = "io.zipkin.brave:brave-instrumentation-http" }
-brave-opentracing = { module = "io.opentracing.brave:brave-opentracing" }
-zipkin-reporter = { module = "io.zipkin.reporter2:zipkin-reporter" }
 rxjava2 = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rxjava2" }
 rxjava3 = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava3" }

--- a/reactor-bom/build.gradle.kts
+++ b/reactor-bom/build.gradle.kts
@@ -3,7 +3,8 @@ plugins {
 }
 micronautBom {
     suppressions {
-        acceptedVersionRegressions.add("reactor-compat")
-        acceptedLibraryRegressions.add("reactor")
+        bomAuthorizedGroupIds.put("io.projectreactor:reactor-bom", setOf("org.reactivestreams"))
+        acceptedVersionRegressions.addAll("reactor", "reactor-compat")
+        acceptedLibraryRegressions.addAll("reactor", "reactor-core", "reactor-test")
     }
 }

--- a/reactor-http-client/build.gradle
+++ b/reactor-http-client/build.gradle
@@ -5,14 +5,10 @@ plugins {
 dependencies {
     annotationProcessor(mn.micronaut.graal)
 
-    api project(":reactor")
+    api(project(":reactor"))
     api(mn.micronaut.http.client)
 
     testImplementation(libs.rxjava2)
-    testImplementation(libs.rxjava3)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.tracing.zipkin)
-    testImplementation(libs.brave.instrumentation.http)
-    testImplementation(libs.zipkin.reporter)
-    testImplementation(libs.brave.opentracing)
 }

--- a/reactor/build.gradle
+++ b/reactor/build.gradle
@@ -9,5 +9,4 @@ dependencies {
 
     compileOnly(libs.rxjava2)
     compileOnly(libs.rxjava3)
-    compileOnly(mn.micronaut.tracing.zipkin)
 }

--- a/reactor/build.gradle
+++ b/reactor/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     annotationProcessor(mn.micronaut.graal)
 
-    api(libs.managed.reactor.core)
+    api(libs.reactor.core)
 
     compileOnly(libs.rxjava2)
     compileOnly(libs.rxjava3)


### PR DESCRIPTION
This PR will fix this issue: https://github.com/micronaut-projects/micronaut-core/issues/6515.

On top of that, I did some cleanup and moved some versions from `gradle.properties` to Gradle Version Catalog to align with the current `micronaut-project-template` standard.