### PR TITLE
Add managed reactor-core and reactor-test to catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ rxjava2 = "2.2.21"
 rxjava3 = "3.1.5"
 
 # When updated be sure to update the versions in the catalog of reactor-bom/build.gradle.kts
-managed-reactor-bom = "2020.0.24"
+managed-reactor-bom = "2022.0.0"
 
 [libraries]
 boms-reactor = { module = "io.projectreactor:reactor-bom", version.ref = "managed-reactor-bom" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,11 +11,15 @@ micronaut-tracing = "5.0.0-SNAPSHOT"
 rxjava2 = "2.2.21"
 rxjava3 = "3.1.5"
 
-# When updated be sure to update the versions in the catalog of reactor-bom/build.gradle.kts
+# These two must be kept aligned as the reactor-bom doesn't have version properties
 managed-reactor-bom = "2022.0.0"
+managed-reactor = "3.5.0"
 
 [libraries]
 boms-reactor = { module = "io.projectreactor:reactor-bom", version.ref = "managed-reactor-bom" }
+
+managed-reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "managed-reactor" }
+managed-reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "managed-reactor" }
 
 micronaut-tracing = { module = "io.micronaut.tracing:micronaut-tracing-bom", version.ref = "micronaut-tracing" }
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ micronaut-tracing = "5.0.0-SNAPSHOT"
 rxjava2 = "2.2.21"
 rxjava3 = "3.1.5"
 
+# When updated be sure to update the versions in the catalog of reactor-bom/build.gradle.kts
 managed-reactor-bom = "2020.0.24"
 
 [libraries]
@@ -20,5 +21,6 @@ micronaut-tracing = { module = "io.micronaut.tracing:micronaut-tracing-bom", ver
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
 
 reactor-core = { module = "io.projectreactor:reactor-core" }
+
 rxjava2 = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rxjava2" }
 rxjava3 = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,5 @@ managed-reactor-test = { module = "io.projectreactor:reactor-test", version.ref 
 micronaut-tracing = { module = "io.micronaut.tracing:micronaut-tracing-bom", version.ref = "micronaut-tracing" }
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
 
-reactor-core = { module = "io.projectreactor:reactor-core" }
-
 rxjava2 = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rxjava2" }
 rxjava3 = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava3" }

--- a/reactor-bom/build.gradle.kts
+++ b/reactor-bom/build.gradle.kts
@@ -7,4 +7,12 @@ micronautBom {
         acceptedVersionRegressions.addAll("reactor", "reactor-compat")
         acceptedLibraryRegressions.addAll("reactor", "reactor-core", "reactor-test")
     }
+    catalog {
+        // We want to be able to reference these versions from other modules that import the catalog of this project
+        versionCatalog {
+            version("reactor", "3.5.0")
+            library("reactor-core", "io.projectreactor", "reactor-core").versionRef("reactor")
+            library("reactor-test", "io.projectreactor", "reactor-test").versionRef("reactor")
+        }
+    }
 }

--- a/reactor-bom/build.gradle.kts
+++ b/reactor-bom/build.gradle.kts
@@ -4,15 +4,7 @@ plugins {
 micronautBom {
     suppressions {
         bomAuthorizedGroupIds.put("io.projectreactor:reactor-bom", setOf("org.reactivestreams"))
-        acceptedVersionRegressions.addAll("reactor", "reactor-compat")
-        acceptedLibraryRegressions.addAll("reactor", "reactor-core", "reactor-test")
-    }
-    catalog {
-        // We want to be able to reference these versions from other modules that import the catalog of this project
-        versionCatalog {
-            version("reactor", "3.5.0")
-            library("reactor-core", "io.projectreactor", "reactor-core").versionRef("reactor")
-            library("reactor-test", "io.projectreactor", "reactor-test").versionRef("reactor")
-        }
+        acceptedVersionRegressions.addAll("reactor-compat")
+        acceptedLibraryRegressions.addAll("reactor")
     }
 }

--- a/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/TraceInterceptorSpec.groovy
+++ b/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/TraceInterceptorSpec.groovy
@@ -53,7 +53,7 @@ class TraceInterceptorSpec extends Specification {
             return Mono.fromCallable({
                 spanCustomizer.tag("foo", "bar")
                 return name
-            }).subscribeOn(Schedulers.elastic())
+            }).subscribeOn(Schedulers.boundedElastic())
         }
     }
 

--- a/reactor/build.gradle
+++ b/reactor/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     annotationProcessor(mn.micronaut.graal)
 
-    api(libs.reactor.core)
+    api(libs.managed.reactor.core)
 
     compileOnly(libs.rxjava2)
     compileOnly(libs.rxjava3)


### PR DESCRIPTION
When switching microstream to the latest build for micronaut 4.0.0, it raised an issue

https://github.com/micronaut-projects/micronaut-microstream/pull/144

We could pull reactor-core from the core-bom, but as it didn't contain reactor-test we had to jump through hoops.

In https://github.com/micronaut-projects/micronaut-reactor/pull/248 we swiched to using the reactor bom instead of managed dependencies.

But as the reactor-bom hard-codes versions instead of setting them as properties we need to specify the version of reactor-core and reactor-test that we want to include.

The downside here is we will need to keep them in sync whenever the BOM version gets updated