### PR TITLE
Allow to use Micrometer Context Propagation

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,3 +1,12 @@
 plugins {
     id 'groovy-gradle-plugin'
 }
+
+repositories {
+    gradlePluginPortal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation libs.gradle.micronaut
+}

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.reactor-test-suite.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.reactor-test-suite.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'io.micronaut.build.internal.reactor-base'
+    id 'java'
+    id 'groovy'
+    id 'io.micronaut.minimal.application'
+}
+micronaut {
+    // Do not build examples against M1 since the platform is not released
+    version libs.versions.micronaut.platform.get()
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+}
+
+configurations.configureEach {
+    resolutionStrategy.preferProjectModules()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,11 +9,15 @@ micronaut-logging = "1.0.0-M4"
 micronaut-serde = "2.0.0-M10"
 micronaut-tracing = "5.0.0-M3"
 micronaut-validation = "4.0.0-M10"
+micronaut-platform = '4.0.0-M3'
 
 rxjava2 = "2.2.21"
 rxjava3 = "3.1.6"
 
 managed-reactor-bom = "2022.0.8"
+managed-micrometer-context-propagation = "1.0.3"
+
+micronaut-gradle-plugin = "4.0.0-M4"
 
 [libraries]
 # Core
@@ -25,7 +29,12 @@ boms-reactor = { module = "io.projectreactor:reactor-bom", version.ref = "manage
 micronaut-tracing = { module = "io.micronaut.tracing:micronaut-tracing-bom", version.ref = "micronaut-tracing" }
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
+micronaut-test = { module = "io.micronaut.test:micronaut-test-bom", version.ref = "micronaut-test" }
 
 reactor-core = { module = "io.projectreactor:reactor-core" }
 rxjava2 = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rxjava2" }
 rxjava3 = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava3" }
+
+managed-micrometer-context-propagation = { module = "io.micrometer:context-propagation", version.ref = "managed-micrometer-context-propagation" }
+
+gradle-micronaut = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = "micronaut-gradle-plugin" }

--- a/reactor/build.gradle
+++ b/reactor/build.gradle
@@ -5,8 +5,9 @@ plugins {
 dependencies {
     annotationProcessor(mn.micronaut.graal)
 
-    api(libs.reactor.core)
+    api libs.reactor.core
 
+    compileOnly libs.managed.micrometer.context.propagation
     compileOnly(libs.rxjava2)
     compileOnly(libs.rxjava3)
     compileOnly(mnTracing.micronaut.tracing.brave.http) {

--- a/reactor/src/main/java/io/micronaut/reactor/config/ReactorConfiguration.java
+++ b/reactor/src/main/java/io/micronaut/reactor/config/ReactorConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.reactor.config;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * The Reactor configuration.
+ *
+ * @author Denis Stepanov
+ * @see 3.0.0
+ */
+@Internal
+@ConfigurationProperties("reactor")
+public final class ReactorConfiguration {
+
+    @Nullable
+    private Boolean enableAutomaticContextPropagation;
+    @Nullable
+    private Boolean enableScheduleHookContextPropagation;
+
+    public Boolean getEnableAutomaticContextPropagation() {
+        return enableAutomaticContextPropagation;
+    }
+
+    public void setEnableAutomaticContextPropagation(Boolean enableAutomaticContextPropagation) {
+        this.enableAutomaticContextPropagation = enableAutomaticContextPropagation;
+    }
+
+    public Boolean getEnableScheduleHookContextPropagation() {
+        return enableScheduleHookContextPropagation;
+    }
+
+    public void setEnableScheduleHookContextPropagation(Boolean enableScheduleHookContextPropagation) {
+        this.enableScheduleHookContextPropagation = enableScheduleHookContextPropagation;
+    }
+}

--- a/reactor/src/main/java/io/micronaut/reactor/config/ReactorConfiguration.java
+++ b/reactor/src/main/java/io/micronaut/reactor/config/ReactorConfiguration.java
@@ -22,31 +22,14 @@ import io.micronaut.core.annotation.Nullable;
 /**
  * The Reactor configuration.
  *
+ * @param enableAutomaticContextPropagation    Enables thread-local propagation in the Reactor context (Only available when if Micrometer context propagation is on the classpath)
+ * @param enableScheduleHookContextPropagation Enables propagation by instrumenting the schedule hook and capturing {@link io.micronaut.core.propagation.PropagatedContext} when the job is scheduled.
  * @author Denis Stepanov
  * @see 3.0.0
  */
 @Internal
 @ConfigurationProperties("reactor")
-public final class ReactorConfiguration {
+public record ReactorConfiguration(@Nullable Boolean enableAutomaticContextPropagation,
+                                   @Nullable Boolean enableScheduleHookContextPropagation) {
 
-    @Nullable
-    private Boolean enableAutomaticContextPropagation;
-    @Nullable
-    private Boolean enableScheduleHookContextPropagation;
-
-    public Boolean getEnableAutomaticContextPropagation() {
-        return enableAutomaticContextPropagation;
-    }
-
-    public void setEnableAutomaticContextPropagation(Boolean enableAutomaticContextPropagation) {
-        this.enableAutomaticContextPropagation = enableAutomaticContextPropagation;
-    }
-
-    public Boolean getEnableScheduleHookContextPropagation() {
-        return enableScheduleHookContextPropagation;
-    }
-
-    public void setEnableScheduleHookContextPropagation(Boolean enableScheduleHookContextPropagation) {
-        this.enableScheduleHookContextPropagation = enableScheduleHookContextPropagation;
-    }
 }

--- a/reactor/src/main/java/io/micronaut/reactor/instrument/ReactorAutomaticContextPropagation.java
+++ b/reactor/src/main/java/io/micronaut/reactor/instrument/ReactorAutomaticContextPropagation.java
@@ -49,8 +49,8 @@ final class ReactorAutomaticContextPropagation {
     private final boolean enableScheduleHookContextPropagation;
 
     ReactorAutomaticContextPropagation(ReactorConfiguration configuration) {
-        this.enableAutomaticContextPropagation = Optional.ofNullable(configuration.getEnableAutomaticContextPropagation()).orElse(true);
-        this.enableScheduleHookContextPropagation = Optional.ofNullable(configuration.getEnableScheduleHookContextPropagation()).orElse(false);
+        this.enableAutomaticContextPropagation = Optional.ofNullable(configuration.enableAutomaticContextPropagation()).orElse(true);
+        this.enableScheduleHookContextPropagation = Optional.ofNullable(configuration.enableScheduleHookContextPropagation()).orElse(false);
     }
 
     @PostConstruct

--- a/reactor/src/main/java/io/micronaut/reactor/instrument/ReactorAutomaticContextPropagation.java
+++ b/reactor/src/main/java/io/micronaut/reactor/instrument/ReactorAutomaticContextPropagation.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.reactor.instrument;
+
+import io.micrometer.context.ContextRegistry;
+import io.micrometer.context.ThreadLocalAccessor;
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.reactor.config.ReactorConfiguration;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import reactor.core.publisher.Hooks;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.ArrayDeque;
+import java.util.Optional;
+
+/**
+ * Integrate {@link PropagatedContext} with Reactor and Micrometer Context Propagation.
+ *
+ * @author Denis Stepanov
+ * @since 4.0.0
+ */
+@Requires(classes = {Schedulers.class, ContextRegistry.class, PropagatedContext.class})
+@Context
+@Internal
+@Replaces(ReactorInstrumentation.class)
+final class ReactorAutomaticContextPropagation {
+
+    private static final PropagatedContextThreadLocalAccessor ACCESSOR = new PropagatedContextThreadLocalAccessor();
+
+    private final boolean enableAutomaticContextPropagation;
+    private final boolean enableScheduleHookContextPropagation;
+
+    ReactorAutomaticContextPropagation(ReactorConfiguration configuration) {
+        this.enableAutomaticContextPropagation = Optional.ofNullable(configuration.getEnableAutomaticContextPropagation()).orElse(true);
+        this.enableScheduleHookContextPropagation = Optional.ofNullable(configuration.getEnableScheduleHookContextPropagation()).orElse(false);
+    }
+
+    @PostConstruct
+    void init() {
+        if (enableScheduleHookContextPropagation) {
+            Schedulers.onScheduleHook(ReactorInstrumentation.KEY, PropagatedContext::wrapCurrent);
+        }
+        if (enableAutomaticContextPropagation) {
+            Hooks.enableAutomaticContextPropagation();
+            ContextRegistry.getInstance()
+                .registerThreadLocalAccessor(ACCESSOR);
+        }
+    }
+
+    @PreDestroy
+    void removeInstrumentation() {
+        if (enableScheduleHookContextPropagation) {
+            Schedulers.resetOnScheduleHook(ReactorInstrumentation.KEY);
+        }
+        if (enableAutomaticContextPropagation) {
+            ContextRegistry.getInstance().removeThreadLocalAccessor(ACCESSOR.key());
+        }
+    }
+
+    private static class PropagatedContextThreadLocalAccessor implements ThreadLocalAccessor<PropagatedContext> {
+
+        private final ThreadLocal<ArrayDeque<PropagatedContext.Scope>> localScopes = new ThreadLocal<>();
+
+        @Override
+        public String key() {
+            // TODO: replace with ReactorPropagation.PROPAGATED_CONTEXT_REACTOR_CONTEXT_VIEW_KEY
+            return "micronaut.propagated.context";
+        }
+
+        @Override
+        public PropagatedContext getValue() {
+            return PropagatedContext.find().orElse(null);
+        }
+
+        @Override
+        public void setValue(PropagatedContext propagatedContext) {
+            ArrayDeque<PropagatedContext.Scope> scopes = localScopes.get();
+            if (scopes == null) {
+                scopes = new ArrayDeque<>(5);
+                localScopes.set(scopes);
+            }
+            scopes.push(propagatedContext.propagate());
+        }
+
+        @Override
+        public void setValue() {
+            // Do nothing
+        }
+
+        @Override
+        public void restore(PropagatedContext previousValue) {
+            ArrayDeque<PropagatedContext.Scope> scopes = localScopes.get();
+            if (scopes != null && !scopes.isEmpty()) {
+                scopes.pop().close();
+                if (scopes.isEmpty()) {
+                    localScopes.remove();
+                }
+            }
+        }
+
+        @Override
+        public void restore() {
+        }
+    }
+}

--- a/reactor/src/main/java/io/micronaut/reactor/instrument/ReactorInstrumentation.java
+++ b/reactor/src/main/java/io/micronaut/reactor/instrument/ReactorInstrumentation.java
@@ -19,10 +19,12 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.reactor.config.ReactorConfiguration;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
+
+import java.util.Optional;
 
 /**
  * Instruments Reactor such that the thread factory used by Micronaut is used and instrumentations can be applied to the {@link java.util.concurrent.ScheduledExecutorService}.
@@ -30,21 +32,30 @@ import reactor.core.scheduler.Schedulers;
  * @author Graeme Rocher
  * @since 1.0
  */
-@Requires(sdk = Requires.Sdk.MICRONAUT, version = "2.0.0")
-@Requires(classes = {Flux.class, Schedulers.Factory.class, PropagatedContext.class})
+@Requires(classes = {Schedulers.Factory.class, PropagatedContext.class})
 @Context
 @Internal
 final class ReactorInstrumentation {
 
-    private static final String KEY = "MICRONAUT_CONTEXT_PROPAGATION";
+    static final String KEY = "MICRONAUT_CONTEXT_PROPAGATION";
+
+    private final boolean enableScheduleHookContextPropagation;
+
+    ReactorInstrumentation(ReactorConfiguration configuration) {
+        this.enableScheduleHookContextPropagation = Optional.ofNullable(configuration.getEnableScheduleHookContextPropagation()).orElse(true);
+    }
 
     @PostConstruct
     void init() {
-        Schedulers.onScheduleHook(KEY, PropagatedContext::wrapCurrent);
+        if (enableScheduleHookContextPropagation) {
+            Schedulers.onScheduleHook(KEY, PropagatedContext::wrapCurrent);
+        }
     }
 
     @PreDestroy
     void removeInstrumentation() {
-        Schedulers.resetOnScheduleHook(KEY);
+        if (enableScheduleHookContextPropagation) {
+            Schedulers.resetOnScheduleHook(KEY);
+        }
     }
 }

--- a/reactor/src/main/java/io/micronaut/reactor/instrument/ReactorInstrumentation.java
+++ b/reactor/src/main/java/io/micronaut/reactor/instrument/ReactorInstrumentation.java
@@ -42,7 +42,7 @@ final class ReactorInstrumentation {
     private final boolean enableScheduleHookContextPropagation;
 
     ReactorInstrumentation(ReactorConfiguration configuration) {
-        this.enableScheduleHookContextPropagation = Optional.ofNullable(configuration.getEnableScheduleHookContextPropagation()).orElse(true);
+        this.enableScheduleHookContextPropagation = Optional.ofNullable(configuration.enableScheduleHookContextPropagation()).orElse(true);
     }
 
     @PostConstruct

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,9 @@ include 'reactor'
 include 'reactor-bom'
 include 'reactor-http-client'
 
+include 'tests:micrometer-propagation'
+include 'tests:simple-propagation'
+
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 micronautBuild {
@@ -24,4 +27,5 @@ micronautBuild {
     importMicronautCatalog("micronaut-logging")
     importMicronautCatalog("micronaut-serde")
     importMicronautCatalog("micronaut-validation")
+    importMicronautCatalog("micronaut-test")
 }

--- a/tests/micrometer-propagation/build.gradle
+++ b/tests/micrometer-propagation/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'io.micronaut.build.internal.reactor-test-suite'
+}
+
+dependencies {
+    testAnnotationProcessor mn.micronaut.inject
+
+    testImplementation platform(libs.boms.reactor)
+    testImplementation projects.micronautReactor
+    testImplementation libs.managed.micrometer.context.propagation
+
+    testImplementation mn.micronaut.http.client
+    testImplementation mn.micronaut.http.server.netty
+    testImplementation mn.micronaut.inject.java.test
+    testImplementation mn.micronaut.jackson.databind
+
+    testImplementation mnTest.micronaut.test.spock
+}

--- a/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/MyTrace.java
+++ b/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/MyTrace.java
@@ -1,0 +1,21 @@
+package io.micronaut.context.propagation;
+
+import io.micronaut.aop.Around;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Around
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+@interface MyTrace {
+}
+
+

--- a/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java
+++ b/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java
@@ -1,0 +1,83 @@
+package io.micronaut.context.propagation;
+
+import io.micronaut.aop.InterceptedMethod;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.async.propagation.ReactorPropagation;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.core.propagation.PropagatedContextElement;
+import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Singleton
+@InterceptorBean(MyTrace.class)
+class MyTracingInterceptor implements MethodInterceptor<Object, Object> {
+
+    List<Trace> traces = new ArrayList<>();
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        Trace trace = new Trace();
+        traces.add(trace);
+        try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
+            .plus(new TracePropagatedContext(trace))
+            .propagate()) {
+            PropagatedContext propagatedContext = PropagatedContext.get();
+            InterceptedMethod interceptedMethod = InterceptedMethod.of(context, ConversionService.SHARED);
+            return switch (interceptedMethod.resultType()) {
+                case PUBLISHER -> captureContext(
+                    interceptedMethod.handleResult(
+                        captureContext(interceptedMethod.interceptResultAsPublisher(), propagatedContext)
+                    ), propagatedContext
+                );
+                case SYNCHRONOUS, COMPLETION_STAGE -> interceptedMethod.handleResult(
+                    interceptedMethod.interceptResult()
+                );
+            };
+        }
+    }
+
+    private <T> T captureContext(T result, PropagatedContext propagatedContext) {
+        if (result instanceof Mono<?> mono) {
+            return (T) mono.contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext));
+        }
+        if (result instanceof Flux<?> flux) {
+            return (T) flux.contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext));
+        }
+        return result;
+    }
+
+    public Trace getCurrectTrace() {
+        return PropagatedContext.getOrEmpty().find(TracePropagatedContext.class).orElseThrow().trace();
+    }
+
+    public Optional<Trace> findCurrentTrace() {
+        return PropagatedContext.getOrEmpty().find(TracePropagatedContext.class).map(c -> c.trace());
+    }
+
+    private record TracePropagatedContext(Trace trace) implements PropagatedContextElement {
+    }
+
+    static class Trace {
+
+        private final Map<String, String> tags = new HashMap<>();
+
+        public void tag(String s1, String s2) {
+            tags.put(s1, s2);
+        }
+
+        public Map<String, String> tags() {
+            return tags;
+        }
+    }
+}

--- a/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/SimpleTraceInterceptorSpec.groovy
+++ b/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/SimpleTraceInterceptorSpec.groovy
@@ -1,0 +1,53 @@
+package io.micronaut.context.propagation
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+class SimpleTraceInterceptorSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ["reactor.enableAutomaticContextPropagation": false])
+
+    void "test trace mono"() {
+        when:
+            TracedService tracedService = embeddedServer.getApplicationContext().getBean(TracedService)
+            String result = tracedService.mono("test").block()
+            PollingConditions conditions = new PollingConditions(timeout: 3)
+
+        then:
+            conditions.eventually {
+                result == "test"
+                def traces = tracedService.tracingInterceptor.traces
+                traces[0].tags().get("foo") == "bar"
+            }
+    }
+
+    @Singleton
+    static class TracedService {
+
+        @Inject
+        MyTracingInterceptor tracingInterceptor
+
+        @MyTrace
+        Mono<String> mono(String name) {
+            def trace = tracingInterceptor.getCurrectTrace()
+            return Mono.fromCallable({
+                if (tracingInterceptor.findCurrentTrace().isPresent()) {
+                    throw new IllegalStateException("Propagation not expected!")
+                }
+                trace.tag("foo", "bar")
+                return name
+            }).subscribeOn(Schedulers.boundedElastic())
+        }
+    }
+
+}

--- a/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/ThreadLocalPropagatedTraceInterceptorSpec.groovy
+++ b/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/ThreadLocalPropagatedTraceInterceptorSpec.groovy
@@ -1,0 +1,73 @@
+package io.micronaut.context.propagation
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+class ThreadLocalPropagatedTraceInterceptorSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer)
+
+    void "test trace mono"() {
+        when:
+            TracedService tracedService = embeddedServer.getApplicationContext().getBean(TracedService)
+            tracedService.tracingInterceptor.traces.clear()
+            String result = tracedService.mono("test").block()
+            PollingConditions conditions = new PollingConditions(timeout: 3)
+
+        then:
+            conditions.eventually {
+                result == "test"
+                def traces = tracedService.tracingInterceptor.traces
+                traces[0].tags().get("fooMono") == "bar"
+            }
+    }
+
+    void "test trace flux"() {
+        when:
+            TracedService tracedService = embeddedServer.getApplicationContext().getBean(TracedService)
+            tracedService.tracingInterceptor.traces.clear()
+            String result = tracedService.flux("test").collectList().block()
+            PollingConditions conditions = new PollingConditions(timeout: 3)
+
+        then:
+            conditions.eventually {
+                def traces = tracedService.tracingInterceptor.traces
+                traces[0].tags().get("fooFlux") == "bar"
+            }
+    }
+
+    @Singleton
+    static class TracedService {
+
+        @Inject
+        MyTracingInterceptor tracingInterceptor
+
+        @MyTrace
+        Mono<String> mono(String name) {
+            return Mono.fromCallable({
+                tracingInterceptor.getCurrectTrace().tag("fooMono", "bar")
+                return name
+            }).subscribeOn(Schedulers.boundedElastic())
+        }
+
+        @MyTrace
+        Flux<String> flux(String name) {
+            return Mono.fromCallable {
+                tracingInterceptor.getCurrectTrace().tag("fooFlux", "bar")
+                return name
+            }.flatMapMany { x -> Flux.just(x) }.subscribeOn(Schedulers.boundedElastic())
+        }
+    }
+
+}

--- a/tests/simple-propagation/build.gradle
+++ b/tests/simple-propagation/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'io.micronaut.build.internal.reactor-test-suite'
+}
+
+dependencies {
+    testAnnotationProcessor mn.micronaut.inject
+
+    testImplementation platform(libs.boms.reactor)
+    testImplementation projects.micronautReactor
+
+    testImplementation mn.micronaut.http.client
+    testImplementation mn.micronaut.http.server.netty
+    testImplementation mn.micronaut.inject.java.test
+    testImplementation mn.micronaut.jackson.databind
+
+    testImplementation mnTest.micronaut.test.spock
+}

--- a/tests/simple-propagation/src/test/groovy/io/micronaut/context/propagation/MyTrace.java
+++ b/tests/simple-propagation/src/test/groovy/io/micronaut/context/propagation/MyTrace.java
@@ -1,0 +1,21 @@
+package io.micronaut.context.propagation;
+
+import io.micronaut.aop.Around;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Around
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+@interface MyTrace {
+}
+
+

--- a/tests/simple-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java
+++ b/tests/simple-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java
@@ -1,0 +1,83 @@
+package io.micronaut.context.propagation;
+
+import io.micronaut.aop.InterceptedMethod;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.async.propagation.ReactorPropagation;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.core.propagation.PropagatedContextElement;
+import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Singleton
+@InterceptorBean(MyTrace.class)
+class MyTracingInterceptor implements MethodInterceptor<Object, Object> {
+
+    List<Trace> traces = new ArrayList<>();
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        Trace trace = new Trace();
+        traces.add(trace);
+        try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
+            .plus(new TracePropagatedContext(trace))
+            .propagate()) {
+            PropagatedContext propagatedContext = PropagatedContext.get();
+            InterceptedMethod interceptedMethod = InterceptedMethod.of(context, ConversionService.SHARED);
+            return switch (interceptedMethod.resultType()) {
+                case PUBLISHER -> captureContext(
+                    interceptedMethod.handleResult(
+                        captureContext(interceptedMethod.interceptResultAsPublisher(), propagatedContext)
+                    ), propagatedContext
+                );
+                case SYNCHRONOUS, COMPLETION_STAGE -> interceptedMethod.handleResult(
+                    interceptedMethod.interceptResult()
+                );
+            };
+        }
+    }
+
+    private <T> T captureContext(T result, PropagatedContext propagatedContext) {
+        if (result instanceof Mono<?> mono) {
+            return (T) mono.contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext));
+        }
+        if (result instanceof Flux<?> flux) {
+            return (T) flux.contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext));
+        }
+        return result;
+    }
+
+    public Trace getCurrectTrace() {
+        return PropagatedContext.getOrEmpty().find(TracePropagatedContext.class).orElseThrow().trace();
+    }
+
+    public Optional<Trace> findCurrentTrace() {
+        return PropagatedContext.getOrEmpty().find(TracePropagatedContext.class).map(c -> c.trace());
+    }
+
+    private record TracePropagatedContext(Trace trace) implements PropagatedContextElement {
+    }
+
+    static class Trace {
+
+        private final Map<String, String> tags = new HashMap<>();
+
+        public void tag(String s1, String s2) {
+            tags.put(s1, s2);
+        }
+
+        public Map<String, String> tags() {
+            return tags;
+        }
+    }
+}

--- a/tests/simple-propagation/src/test/groovy/io/micronaut/context/propagation/SimpleTraceInterceptorSpec.groovy
+++ b/tests/simple-propagation/src/test/groovy/io/micronaut/context/propagation/SimpleTraceInterceptorSpec.groovy
@@ -1,0 +1,53 @@
+package io.micronaut.context.propagation
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+class SimpleTraceInterceptorSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer)
+
+    void "test trace mono"() {
+        when:
+            TracedService tracedService = embeddedServer.getApplicationContext().getBean(TracedService)
+            String result = tracedService.mono("test").block()
+            PollingConditions conditions = new PollingConditions(timeout: 3)
+
+        then:
+            conditions.eventually {
+                result == "test"
+                def traces = tracedService.tracingInterceptor.traces
+                traces[0].tags().get("foo") == "bar"
+            }
+    }
+
+    @Singleton
+    static class TracedService {
+
+        @Inject
+        MyTracingInterceptor tracingInterceptor
+
+        @MyTrace
+        Mono<String> mono(String name) {
+            def trace = tracingInterceptor.getCurrectTrace()
+            return Mono.fromCallable({
+                if (tracingInterceptor.findCurrentTrace().isPresent()) {
+                    throw new IllegalStateException("Propagation not expected!")
+                }
+                trace.tag("foo", "bar")
+                return name
+            }).subscribeOn(Schedulers.boundedElastic())
+        }
+    }
+
+}


### PR DESCRIPTION
Micrometer Context Propagation is used if present on the classpath, otherwise fallback to simple thread executor instrumentation propagation