### PR TITLE
Reactor to RC5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 micronaut = "4.0.0-RC5"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.0.0-M8"
-groovy = "4.0.10"
+groovy = "4.0.13"
 spock = "2.3-groovy-4.0"
 
 micronaut-logging = "1.0.0-M5"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ micronaut-logging = "1.0.0-M5"
 micronaut-serde = "2.0.0-M12"
 micronaut-tracing = "5.0.0-M6"
 micronaut-validation = "4.0.0-M11"
-micronaut-platform = '4.0.0-M3'
+micronaut-platform = '4.0.0-M5'
 
 rxjava2 = "2.2.21"
 rxjava3 = "3.1.6"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.0.0-RC4"
+micronaut = "4.0.0-RC5"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.0.0-M8"
 groovy = "4.0.10"

--- a/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/StreamSpec.groovy
+++ b/reactor-http-client/src/test/groovy/io/micronaut/reactor/http/client/StreamSpec.groovy
@@ -34,14 +34,14 @@ class StreamSpec extends Specification {
     @Client('/stream')
     static interface StreamEchoClient {
         @Get(value = "/echo{?n,data}", consumes = MediaType.TEXT_PLAIN)
-        Flux<byte[]> echoAsByteArrays(@QueryValue @Nullable int n, @QueryValue @Nullable String data);
+        Flux<byte[]> echoAsByteArrays(@QueryValue @Nullable Integer n, @QueryValue @Nullable String data);
     }
 
     @Controller('/stream')
     static class StreamEchoController {
 
         @Get(value = "/echo{?n,data}", produces = MediaType.TEXT_PLAIN)
-        Flux<byte[]> stream(@QueryValue @Nullable int n, @QueryValue @Nullable String data) {
+        Flux<byte[]> stream(@QueryValue @Nullable Integer n, @QueryValue @Nullable String data) {
             return Flux.just(data.getBytes(StandardCharsets.UTF_8)).repeat(n - 1)
         }
 


### PR DESCRIPTION
Groovy compilation fails with : 

```
> Task :micronaut-tests:micronaut-simple-propagation:compileTestGroovy FAILED

> Task :micronaut-tests:micronaut-micrometer-propagation:compileTestGroovy FAILED
Note: Creating bean classes for 1 type elements
Note: /Users/sdelamo/github/micronaut-projects/micronaut-reactor/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':micronaut-tests:micronaut-micrometer-propagation:compileTestGroovy'.
> Receiver class io.micronaut.ast.groovy.visitor.GroovyClassElement$GroovyEnclosedElementsQuery does not define or inherit an implementation of the resolved method 'abstract java.lang.String getElementName(java.lang.Object)' of abstract class io.micronaut.inject.ast.utils.EnclosedElementsQuery.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':micronaut-tests:micronaut-simple-propagation:compileTestGroovy'.
> Receiver class io.micronaut.ast.groovy.visitor.GroovyClassElement$GroovyEnclosedElementsQuery does not define or inherit an implementation of the resolved method 'abstract java.lang.String getElementName(java.lang.Object)' of abstract class io.micronaut.inject.ast.utils.EnclosedElementsQuery.


```