### PR TITLE
Document io.micrometer:context-propagation

### DIFF
--- a/src/main/docs/guide/contextPropagation.adoc
+++ b/src/main/docs/guide/contextPropagation.adoc
@@ -1,0 +1,28 @@
+Since Micronaut Framework version 4, https://projectreactor.io[Project Reactor] integration no longer captures the state automatically. Micronaut Framework users need to extend the propagation context manually.
+
+Before version 4, Micronaut Framework required the instrumentation of every reactive operator to capture the current state to propagate it. It added an unwanted overhead and forced us to maintain complicated Reactor operators' instrumentation.
+
+Since 3.5.0, Reactor-Core embeds support for the `io.micrometer:context-propagation` SPI. This allows to achieve the same thread-local propagation by including the https://micrometer.io/docs/contextPropagation[Micrometer Context Propagation] dependency.
+
+The framework automatically adds the `PropagatedContext` to Project Reactor's context for interceptors and the HTTP filters. You can access it via the utility class link:https://docs.micronaut.io/latest/api/io/micronaut/core/async/propagation/ReactorPropagation.html[ReactorPropagation].
+
+NOTE: link:https://docs.micronaut.io/latest/api/io/micronaut/core/async/propagation/ReactorPropagation.html[ReactorPropagation] is an experimental class and might change in the future.
+
+It is possible to use https://micrometer.io/docs/contextPropagation[Micrometer Context Propagation], which Reactor supports for propagation and restoring the thread-local context.
+
+To enable it, include the dependency:
+
+dependency:context-propagation[groupId="io.micrometer",scope="compile"]
+
+After that, all the thread-local propagated elements can restore their thread-local value.
+
+NOTE: The thread-local values are read-only. To modify them, the `PropagatedContext` instance needs to be changed and put into the Reactor's context.
+
+If you have Micrometer Context Propagation on the classpath but don't want to use it, apply the following configuration:
+
+.Disable Micrometer Context Propagation in Reactor
+[configuration]
+----
+reactor:
+    enable-automatic-context-propagation: false
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -4,5 +4,6 @@ releaseHistory: Release History
 breaks: Breaking Changes
 quickStart:
   title: Quick Start
+contextPropagation: Reactor context propagation
 repository: Repository
 


### PR DESCRIPTION
closes #384

These are the docs from https://docs.micronaut.io/latest/guide/#reactorContextPropagation

@dstepanov do we want to add something about `ReactorAutomaticContextPropagation` in this module?

@sdelamo I think we need an issue for core to remove the docs there and add a link to these docs, yes?