### PR TITLE
Remove exclusion

### DIFF
--- a/reactor/build.gradle
+++ b/reactor/build.gradle
@@ -4,14 +4,16 @@ plugins {
 
 dependencies {
     annotationProcessor(mn.micronaut.graal)
-
+    api platform(libs.boms.reactor)
     api libs.reactor.core
 
     compileOnly libs.managed.micrometer.context.propagation
     compileOnly(libs.rxjava2)
     compileOnly(libs.rxjava3)
-    compileOnly(mnTracing.micronaut.tracing.brave.http) {
-        // fix a cyclic dependency
-        exclude group: 'io.micronaut.reactor'
-    }
+    compileOnly(mnTracing.micronaut.tracing.brave.http)
+}
+
+// Workaround for Gradle bug
+tasks.named("checkstyleMain") {
+   dependsOn(jar)
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,5 +26,4 @@ micronautBuild {
     importMicronautCatalog("micronaut-tracing")
     importMicronautCatalog("micronaut-serde")
     importMicronautCatalog("micronaut-validation")
-    importMicronautCatalog("micronaut-test")
 }


### PR DESCRIPTION
This exclusion should be redundant: the dependency will be substituted by the project dependency automatically. This was probably done before usage of standardized project names.

Keeping this exclusion causes problems with included builds.

See https://ge.micronaut.io/s/nroel37vdzupi/dependencies?focusedDependency=WzEsMSwyNjksWzEsMSxbMTEzLDI2MSwyNjldXV0&toggled=W1sxXSxbMSwxXSxbMSwxLFsxMTNdXSxbMSwxLFsxMTMsMjYxXV1d which shows that the substitution happens even without the exclusion.