### PR TITLE
don't use try with resources and PropagatedContext

### DIFF
--- a/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java
+++ b/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java
@@ -31,10 +31,10 @@ class MyTracingInterceptor implements MethodInterceptor<Object, Object> {
         traces.add(trace);
         PropagatedContext propagatedContext = PropagatedContext.getOrEmpty()
             .plus(new TracePropagatedContext(trace));
-        return propagatedContext.propagate(() -> getObject(context, propagatedContext));
+        return propagatedContext.propagate(() -> interceptWithinContext(context, propagatedContext));
     }
 
-    private @Nullable Object getObject(MethodInvocationContext<Object, Object> context, PropagatedContext propagatedContext) {
+    private @Nullable Object interceptWithinContext(MethodInvocationContext<Object, Object> context, PropagatedContext propagatedContext) {
         InterceptedMethod interceptedMethod = InterceptedMethod.of(context, ConversionService.SHARED);
         return switch (interceptedMethod.resultType()) {
             case PUBLISHER ->

--- a/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java
+++ b/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java
@@ -9,7 +9,7 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.core.propagation.PropagatedContextElement;
 import jakarta.inject.Singleton;
-import org.reactivestreams.Publisher;
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -33,16 +33,20 @@ class MyTracingInterceptor implements MethodInterceptor<Object, Object> {
             .plus(new TracePropagatedContext(trace))
             .propagate()) {
             PropagatedContext propagatedContext = PropagatedContext.get();
-            InterceptedMethod interceptedMethod = InterceptedMethod.of(context, ConversionService.SHARED);
-            return switch (interceptedMethod.resultType()) {
-                case PUBLISHER ->
-                    // Bypass InterceptedMethod logic for testing
-                    captureContext(context.proceed(), propagatedContext);
-                case SYNCHRONOUS, COMPLETION_STAGE -> interceptedMethod.handleResult(
-                    interceptedMethod.interceptResult()
-                );
-            };
+            return getObject(context, propagatedContext);
         }
+    }
+
+    private @Nullable Object getObject(MethodInvocationContext<Object, Object> context, PropagatedContext propagatedContext) {
+        InterceptedMethod interceptedMethod = InterceptedMethod.of(context, ConversionService.SHARED);
+        return switch (interceptedMethod.resultType()) {
+            case PUBLISHER ->
+                // Bypass InterceptedMethod logic for testing
+                captureContext(context.proceed(), propagatedContext);
+            case SYNCHRONOUS, COMPLETION_STAGE -> interceptedMethod.handleResult(
+                interceptedMethod.interceptResult()
+            );
+        };
     }
 
     private <T> T captureContext(T result, PropagatedContext propagatedContext) {

--- a/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java
+++ b/tests/micrometer-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java
@@ -29,12 +29,9 @@ class MyTracingInterceptor implements MethodInterceptor<Object, Object> {
     public Object intercept(MethodInvocationContext<Object, Object> context) {
         Trace trace = new Trace();
         traces.add(trace);
-        try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
-            .plus(new TracePropagatedContext(trace))
-            .propagate()) {
-            PropagatedContext propagatedContext = PropagatedContext.get();
-            return getObject(context, propagatedContext);
-        }
+        PropagatedContext propagatedContext = PropagatedContext.getOrEmpty()
+            .plus(new TracePropagatedContext(trace));
+        return propagatedContext.propagate(() -> getObject(context, propagatedContext));
     }
 
     private @Nullable Object getObject(MethodInvocationContext<Object, Object> context, PropagatedContext propagatedContext) {

--- a/tests/simple-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java
+++ b/tests/simple-propagation/src/test/groovy/io/micronaut/context/propagation/MyTracingInterceptor.java
@@ -29,10 +29,9 @@ class MyTracingInterceptor implements MethodInterceptor<Object, Object> {
     public Object intercept(MethodInvocationContext<Object, Object> context) {
         Trace trace = new Trace();
         traces.add(trace);
-        try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
-            .plus(new TracePropagatedContext(trace))
-            .propagate()) {
-            PropagatedContext propagatedContext = PropagatedContext.get();
+        PropagatedContext propagatedContext = PropagatedContext.getOrEmpty()
+            .plus(new TracePropagatedContext(trace));
+        return propagatedContext.propagate(() -> {
             InterceptedMethod interceptedMethod = InterceptedMethod.of(context, ConversionService.SHARED);
             return switch (interceptedMethod.resultType()) {
                 case PUBLISHER -> captureContext(
@@ -44,7 +43,7 @@ class MyTracingInterceptor implements MethodInterceptor<Object, Object> {
                     interceptedMethod.interceptResult()
                 );
             };
-        }
+        });
     }
 
     private <T> T captureContext(T result, PropagatedContext propagatedContext) {


### PR DESCRIPTION
This removes the usage of the deprecated method `propagate()` in a try with resources context. 